### PR TITLE
Updated CurrentlyRecordingFilter

### DIFF
--- a/src/main/java/sagex/phoenix/vfs/filters/CurrentlyRecordingFilter.java
+++ b/src/main/java/sagex/phoenix/vfs/filters/CurrentlyRecordingFilter.java
@@ -1,5 +1,6 @@
 package sagex.phoenix.vfs.filters;
 
+import sagex.api.AiringAPI;
 import sagex.api.MediaFileAPI;
 import sagex.phoenix.vfs.IMediaFile;
 import sagex.phoenix.vfs.IMediaResource;
@@ -13,7 +14,7 @@ public class CurrentlyRecordingFilter extends Filter {
     public boolean canAccept(IMediaResource res) {
 
         if (res instanceof IMediaFile) {
-            return MediaFileAPI.IsFileCurrentlyRecording(((IMediaFile) res).getMediaObject());
+            return MediaFileAPI.IsFileCurrentlyRecording(((IMediaFile) res).getMediaObject()) && !AiringAPI.IsNotManualOrFavorite(((IMediaFile) res).getMediaObject());
         }
         return false;
     }


### PR DESCRIPTION
CurrentlyRecordingFilter :: It now ignores shows that are being watched but not 'recorded' - ie the
file won't be saved when the recording is finished.